### PR TITLE
plan: return errors instead of log.Fatalf

### DIFF
--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -240,7 +240,7 @@ func SetDNSRecords(ctx context.Context, edns *api.ExternalDNS) ([]api.DNSRecord,
 	cfg := convertEDNSObjectToCfg(edns)
 
 	if err := validation.ValidateConfig(cfg); err != nil {
-		log.Fatalf("config validation failed: %v", err)
+		return nil, fmt.Errorf("config validation failed: %w", err)
 	}
 
 	annotations.SetAnnotationPrefix(cfg.AnnotationPrefix)
@@ -248,7 +248,9 @@ func SetDNSRecords(ctx context.Context, edns *api.ExternalDNS) ([]api.DNSRecord,
 		log.Infof("Using custom annotation prefix: %s", cfg.AnnotationPrefix)
 	}
 
-	configureLogger(cfg)
+	if err := configureLogger(cfg); err != nil {
+		return nil, err
+	}
 
 	/*if log.GetLevel() < log.DebugLevel {
 		// Klog V2 is used by k8s.io/apimachinery/pkg/labels and can throw (a lot) of irrelevant logs
@@ -294,10 +296,12 @@ func SetDNSRecords(ctx context.Context, edns *api.ExternalDNS) ([]api.DNSRecord,
 func DeleteDNSRecords(ctx context.Context, edns *api.ExternalDNS) error {
 	cfg := convertEDNSObjectToCfg(edns)
 	if err := validation.ValidateConfig(cfg); err != nil {
-		log.Fatalf("config validation failed: %v", err)
+		return fmt.Errorf("config validation failed: %w", err)
 	}
 
-	configureLogger(cfg)
+	if err := configureLogger(cfg); err != nil {
+		return err
+	}
 
 	domainFilter := createDomainFilter(cfg)
 
@@ -919,19 +923,20 @@ func createRegistry(cfg *externaldns.Config, p provider.Provider) (registry.Regi
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p, cfg.TXTOwnerID)
 	default:
-		log.Fatalf("unknown registry: %s", cfg.Registry)
+		return nil, fmt.Errorf("unknown registry: %s", cfg.Registry)
 	}
 	return r, err
 }
 
 // This function configures the logger format and level based on the provided configuration.
-func configureLogger(cfg *externaldns.Config) {
+func configureLogger(cfg *externaldns.Config) error {
 	if cfg.LogFormat == "json" {
 		log.SetFormatter(&log.JSONFormatter{})
 	}
 	ll, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
-		log.Fatalf("failed to parse log level: %v", err)
+		return fmt.Errorf("failed to parse log level %q: %w", cfg.LogLevel, err)
 	}
 	log.SetLevel(ll)
+	return nil
 }


### PR DESCRIPTION
## Summary

`pkg/plan` calls `logrus.Fatalf` (which calls `os.Exit(1)`) on four paths:

- `SetDNSRecords` — when `validation.ValidateConfig` rejects the converted config.
- `DeleteDNSRecords` — same.
- `createRegistry` — when the configured registry name is unknown.
- `configureLogger` — when the log level string fails to parse.

A malformed `ExternalDNS` object submitted by any tenant therefore terminates the operator pod and breaks reconciliation for every other `ExternalDNS` on the cluster.

This PR returns the errors instead. The reconciler already surfaces returned errors on `.status.conditions`, so the bad CR ends up `Phase=Failed` with a useful message while the operator keeps running.

`configureLogger` gained an `error` return; its two callers propagate it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Apply an `ExternalDNS` with an invalid `logLevel`/`registry` against a dev cluster and confirm the pod stays up while the CR reports the failure on its status.