### PR TITLE
credentials: write provider credential files as mode 0600

### DIFF
--- a/pkg/credentials/aws.go
+++ b/pkg/credentials/aws.go
@@ -58,7 +58,10 @@ func setAWSCredential(ctx context.Context, kc client.Client, edns *api.ExternalD
 	fileName := fmt.Sprintf("%s-%s-credential", edns.Namespace, edns.Name)
 
 	filePath := fmt.Sprintf("/tmp/%s", fileName)
-	file, err := os.Create(filePath)
+	// Remove any pre-existing file so we don't inherit looser permissions
+	// from an earlier reconcile or an older operator version.
+	_ = os.Remove(filePath)
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentials/azure.go
+++ b/pkg/credentials/azure.go
@@ -51,7 +51,10 @@ func setAzureCredential(ctx context.Context, kc client.Client, edns *api.Externa
 	fileName := fmt.Sprintf("%s-%s-credential", edns.Namespace, edns.Name)
 	filepath := fmt.Sprintf("/tmp/%s", fileName)
 
-	file, err := os.Create(filepath)
+	// Remove any pre-existing file so we don't inherit looser permissions
+	// from an earlier reconcile or an older operator version.
+	_ = os.Remove(filepath)
+	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentials/google.go
+++ b/pkg/credentials/google.go
@@ -57,7 +57,10 @@ func setGoogleCredential(ctx context.Context, kc client.Client, edns *api.Extern
 	fileName := fmt.Sprintf("%s-%s-credential", edns.Namespace, edns.Name)
 	filePath := fmt.Sprintf("/tmp/%s", fileName)
 
-	file, err := os.Create(filePath)
+	// Remove any pre-existing file so we don't inherit looser permissions
+	// from an earlier reconcile or an older operator version.
+	_ = os.Remove(filePath)
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

`pkg/credentials/{aws,azure,google}.go` write the provider's credential blob to `/tmp/<namespace>-<name>-credential` using `os.Create`, which opens with mode `0666 & ~umask` — typically `0644`. The files contain:

- AWS shared-credentials INI
- Google service-account JSON
- Azure cloud config

So anything else running inside the operator pod (sidecar, debug shell, future code that walks `/tmp`) could read them.

Switch to `os.OpenFile` with explicit `0600`. Before opening, the existing file (if any) is removed so we don't inherit looser permissions from an earlier reconcile or an older operator version — `O_CREATE` preserves the existing mode when the file already exists, so without the unlink the chmod-down wouldn't happen for old files.

This is a minimum-viable hardening. Follow-up work (separate PRs) should remove the on-disk hop entirely and clean up these files on CR deletion / operator restart.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Apply an `ExternalDNS` referencing a Secret, then `kubectl exec` into the operator pod and confirm `ls -l /tmp/<ns>-<name>-credential` shows `-rw-------`.