### PR TITLE
controller: set Status.ObservedGeneration on every status patch

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -63,8 +63,10 @@ func newPhase(phase api.ExternalDNSPhase) *api.ExternalDNSPhase {
 
 // update the status of the crd, conditionType is the reason of the condition
 func (r *ExternalDNSReconciler) updateEdnsStatus(ctx context.Context, edns *api.ExternalDNS, newCondition *kmapi.Condition, phase *api.ExternalDNSPhase) error {
+	generation := edns.Generation
 	_, patchErr := kmc.PatchStatus(ctx, r.Client, edns, func(obj client.Object) client.Object {
 		in := obj.(*api.ExternalDNS)
+		in.Status.ObservedGeneration = generation
 		if phase != nil {
 			in.Status.Phase = *phase
 		}
@@ -77,8 +79,10 @@ func (r *ExternalDNSReconciler) updateEdnsStatus(ctx context.Context, edns *api.
 }
 
 func (r ExternalDNSReconciler) patchDNSRecords(ctx context.Context, edns *api.ExternalDNS, dnsRecs []api.DNSRecord) error {
+	generation := edns.Generation
 	_, patchErr := kmc.PatchStatus(ctx, r.Client, edns, func(obj client.Object) client.Object {
 		in := obj.(*api.ExternalDNS)
+		in.Status.ObservedGeneration = generation
 		in.Status.DNSRecords = dnsRecs
 		return in
 	})


### PR DESCRIPTION
## Summary

`apis/external/v1alpha1/externaldns_types.go` declares `Status.ObservedGeneration`, but no code path ever writes it. So consumers (kubectl wait, dashboards, owner controllers) had no way to tell whether the operator had seen the latest spec.

Both helpers that patch the `ExternalDNS` status — `updateEdnsStatus` and `patchDNSRecords` — now set `ObservedGeneration` to the `Generation` captured at the start of the reconcile. This is the standard controller pattern: `ObservedGeneration` advances on both success and failure, since either way the controller has observed and acted on that `Generation`. The conditions array continues to carry per-condition `Generation` so callers can still distinguish stale conditions.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Apply an `ExternalDNS`, then `kubectl get externaldns -o jsonpath='{.status.observedGeneration}'` and confirm it matches `.metadata.generation` after the reconcile settles.
- [ ] Edit the spec; confirm `ObservedGeneration` advances on the next reconcile.