### PR TITLE
controller: use a pointer receiver on patchDNSRecords

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -76,7 +76,7 @@ func (r *ExternalDNSReconciler) updateEdnsStatus(ctx context.Context, edns *api.
 	return patchErr
 }
 
-func (r ExternalDNSReconciler) patchDNSRecords(ctx context.Context, edns *api.ExternalDNS, dnsRecs []api.DNSRecord) error {
+func (r *ExternalDNSReconciler) patchDNSRecords(ctx context.Context, edns *api.ExternalDNS, dnsRecs []api.DNSRecord) error {
 	_, patchErr := kmc.PatchStatus(ctx, r.Client, edns, func(obj client.Object) client.Object {
 		in := obj.(*api.ExternalDNS)
 		in.Status.DNSRecords = dnsRecs


### PR DESCRIPTION
## Summary

`patchDNSRecords` was declared with a value receiver while every other `ExternalDNSReconciler` method uses a pointer receiver:

```go
func (r ExternalDNSReconciler) patchDNSRecords(...)  // before
func (r *ExternalDNSReconciler) patchDNSRecords(...) // after
```

Today benign — the embedded `client.Client` survives the copy — but the next field added to the struct (a cache, a counter, an unexported mutex) would silently lose its mutations when called through this method.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`