### PR TITLE
credentials: unset env vars on reset instead of setting to ""

### DIFF
--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -38,8 +38,7 @@ func getSecret(ctx context.Context, kc client.Client, key types.NamespacedName) 
 
 func resetEnvVariables(list ...string) error {
 	for _, item := range list {
-		err := os.Setenv(item, "")
-		if err != nil {
+		if err := os.Unsetenv(item); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

`resetEnvVariables` cleared each variable with `os.Setenv(name, "")`, which leaves the variable defined-but-empty. Any consumer that uses `os.LookupEnv` (or the equivalent in another language) sees it as present. The intent here is "no value at all" between reconciles for AWS/Google/Cloudflare credential env vars, so use `os.Unsetenv`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`