### PR TITLE
plan: avoid nil pointer dereference in OCI provider build

### DIFF
--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -843,8 +843,8 @@ func buildProvider(
 		} else {
 			config, err = oci.LoadOCIConfig(cfg.OCIConfigFile)
 		}
-		config.ZoneCacheDuration = cfg.OCIZoneCacheDuration
 		if err == nil {
+			config.ZoneCacheDuration = cfg.OCIZoneCacheDuration
 			p, err = oci.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.OCIZoneScope, cfg.DryRun)
 		}
 	case "rfc2136":


### PR DESCRIPTION
## Summary
- If OCI auth setup fails (missing compartment OCID for instance-principal mode, or a `LoadOCIConfig` error), `config` is nil while `err` is non-nil. The very next line dereferenced `config.ZoneCacheDuration` and panicked.
- Move `config.ZoneCacheDuration = ...` and the `NewOCIProvider` call inside the existing `err == nil` guard.

## Test plan
- [ ] `go build ./...`
- [ ] Manually exercise OCI provider with both missing compartment OCID and missing config file paths to confirm a clean error path instead of a panic