### PR TITLE
credentials: reset all provider env vars before configuring a new one

### DIFF
--- a/pkg/credentials/aws.go
+++ b/pkg/credentials/aws.go
@@ -37,10 +37,7 @@ func validAWSSecret(secret *core.Secret, key string) bool {
 }
 
 func setAWSCredential(ctx context.Context, kc client.Client, edns *api.ExternalDNS) error {
-	if err := resetEnvVariables(AWSSharedCredentialsFile); err != nil {
-		return err
-	}
-
+	// Env reset of all provider variables is done centrally in SetCredential.
 	// if ProviderSecretRef is nil then user is intended to use IRSA (IAM Role for Service Account)
 	if edns.Spec.AWS == nil || edns.Spec.AWS.SecretRef == nil {
 		return nil

--- a/pkg/credentials/cloudflare.go
+++ b/pkg/credentials/cloudflare.go
@@ -47,10 +47,7 @@ func validCFSecret(secret *core.Secret, tokenKey, apiKey, apiEmail string) bool 
 }
 
 func setCloudflareCredentials(ctx context.Context, kc client.Client, edns *api.ExternalDNS) error {
-	if err := resetEnvVariables(CFApiToken, CFApiKey, CFApiEmail, CFBaseURL); err != nil {
-		return err
-	}
-
+	// Env reset of all provider variables is done centrally in SetCredential.
 	// ProviderSecretRef is required for cloudflare
 	if edns.Spec.Cloudflare == nil || edns.Spec.Cloudflare.SecretRef == nil {
 		return errors.New("providerSecretRef is not given for cloudflare provider")

--- a/pkg/credentials/google.go
+++ b/pkg/credentials/google.go
@@ -37,10 +37,7 @@ func validGoogleSecret(secret *core.Secret, key string) bool {
 }
 
 func setGoogleCredential(ctx context.Context, kc client.Client, edns *api.ExternalDNS) error {
-	if err := resetEnvVariables(GoogleApplicationCredentials); err != nil {
-		return err
-	}
-
+	// Env reset of all provider variables is done centrally in SetCredential.
 	// if ProviderSecretRef is nil then user is intended to use Workload Identity
 	if edns.Spec.Google == nil || edns.Spec.Google.SecretRef == nil {
 		return nil

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -59,6 +59,8 @@ var providerEnvVars = []string{
 	CFApiToken,
 	CFApiKey,
 	CFApiEmail,
+}
+
 // credentialFilePath returns the on-disk path used by the file-based
 // provider credential setters (AWS / Azure / Google). It must stay in
 // sync with the path each setter writes to.

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -45,7 +45,26 @@ func resetEnvVariables(list ...string) error {
 	return nil
 }
 
+// providerEnvVars enumerates every environment variable any of the
+// supported credential setters may write. Listing them in one place lets
+// SetCredential clear stale entries left over from a previous provider
+// before configuring the new one, so switching providers (or deleting an
+// old ExternalDNS and creating a new one) cannot leak credentials across
+// reconciles.
+var providerEnvVars = []string{
+	AWSSharedCredentialsFile,
+	GoogleApplicationCredentials,
+	CFBaseURL,
+	CFApiToken,
+	CFApiKey,
+	CFApiEmail,
+}
+
 func SetCredential(ctx context.Context, kc client.Client, edns *api.ExternalDNS) error {
+	if err := resetEnvVariables(providerEnvVars...); err != nil {
+		return err
+	}
+
 	switch edns.Spec.Provider {
 	case api.ProviderAWS:
 		return setAWSCredential(ctx, kc, edns)


### PR DESCRIPTION
## Summary
Each provider's credential setter reset only its own env vars (and Azure reset none). Switching providers across reconciles — or deleting one ExternalDNS and creating another with a different provider — would leave stale credentials from the previous provider in the process env.

This change centralizes the env reset in \`SetCredential\` so every known provider env var (AWS / GCP / Cloudflare) is unset before any per-provider setter runs.

## Test plan
- [ ] \`go build ./...\`
- [ ] Manually verify that swapping an ExternalDNS from \`cloudflare\` to \`aws\` no longer leaves \`CF_API_*\` set in the operator process