### PR TITLE
controller: scope the reconcile mutex onto the reconciler

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -40,16 +40,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var mutex sync.Mutex
-
 const finalizer = "externaldns.kubeops.dev/finalizer"
 
-// ExternalDNSReconciler reconciles a ExternalDNS object
+// ExternalDNSReconciler reconciles a ExternalDNS object.
+//
+// reconcileMu serializes the body of Reconcile (and handleDeletion)
+// across all ExternalDNS objects. The serialization is required because
+// the credential layer mutates process-wide state — environment
+// variables and well-known on-disk paths — that two concurrent
+// reconciles for different providers would race on. Removing the lock
+// requires plumbing per-resource credentials through buildProvider
+// instead of relying on env/disk; see TODO.
 type ExternalDNSReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	watcher *informers.ObjectTracker
+	reconcileMu sync.Mutex
+	watcher     *informers.ObjectTracker
 }
 
 func newCondition(reason string, message string, generation int64, conditionStatus bool) *kmapi.Condition {
@@ -149,8 +156,8 @@ func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, patchErr
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
+	r.reconcileMu.Lock()
+	defer r.reconcileMu.Unlock()
 
 	// SECRET AND CREDENTIALS
 	// create and set provider secret credentials and environment variables
@@ -218,8 +225,8 @@ func (r *ExternalDNSReconciler) handleDeletion(ctx context.Context, edns *api.Ex
 		return ctrl.Result{}, nil
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
+	r.reconcileMu.Lock()
+	defer r.reconcileMu.Unlock()
 
 	if edns.Spec.Policy == nil || *edns.Spec.Policy == api.PolicySync {
 		if err := credentials.SetCredential(ctx, r.Client, edns); err != nil {


### PR DESCRIPTION
## Summary
The serialization lock used by \`Reconcile\` and \`handleDeletion\` lived as a package-level \`var mutex sync.Mutex\`. Moving it onto \`ExternalDNSReconciler\` makes its scope obvious and lets the doc comment record why it exists in the first place — the credential layer mutates process-wide env vars and well-known disk paths.

No behavior change. This is the small refactor that paves the way for plumbing per-resource credentials through and dropping the lock entirely.

## Test plan
- [ ] \`go build ./...\`
- [ ] Reconcile a single ExternalDNS to confirm lock contention behavior is identical (only one reconcile at a time)