### PR TITLE
controller: clean up credential temp files on finalizer removal

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -233,6 +233,13 @@ func (r *ExternalDNSReconciler) handleDeletion(ctx context.Context, edns *api.Ex
 		}
 	}
 
+	// Remove the on-disk credential file before dropping the finalizer so
+	// secret material does not linger in /tmp for the life of the pod.
+	if err := credentials.CleanupCredential(edns); err != nil {
+		klog.Errorf("failed to clean up credential file for %s/%s: %v", edns.Namespace, edns.Name, err)
+		return ctrl.Result{}, err
+	}
+
 	controllerutil.RemoveFinalizer(edns, finalizer)
 	return ctrl.Result{}, r.Update(ctx, edns)
 }

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -19,6 +19,7 @@ package credentials
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	api "kubeops.dev/external-dns-operator/apis/external/v1alpha1"
@@ -39,6 +40,28 @@ func getSecret(ctx context.Context, kc client.Client, key types.NamespacedName) 
 func resetEnvVariables(list ...string) error {
 	for _, item := range list {
 		if err := os.Unsetenv(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// credentialFilePath returns the on-disk path used by the file-based
+// provider credential setters (AWS / Azure / Google). It must stay in
+// sync with the path each setter writes to.
+func credentialFilePath(edns *api.ExternalDNS) string {
+	return fmt.Sprintf("/tmp/%s-%s-credential", edns.Namespace, edns.Name)
+}
+
+// CleanupCredential removes any on-disk credential files written by a
+// previous SetCredential call for this ExternalDNS. Safe to call when
+// the file does not exist. Intended to run during finalizer-driven
+// deletion so we don't leak secret material on /tmp across the lifetime
+// of the operator pod.
+func CleanupCredential(edns *api.ExternalDNS) error {
+	switch edns.Spec.Provider {
+	case api.ProviderAWS, api.ProviderAzure, api.ProviderGoogle:
+		if err := os.Remove(credentialFilePath(edns)); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
AWS / Azure / Google credential setters write secret material to \`/tmp/<ns>-<name>-credential\`. \`handleDeletion\` removed the finalizer but never removed the file, so a long-running operator pod accumulated every credential it ever served.

Add \`credentials.CleanupCredential\` and call it from \`handleDeletion\` before the finalizer is removed. No-op for providers that don't use a file (Cloudflare); tolerant of an already-deleted file.

## Test plan
- [ ] \`go build ./...\`
- [ ] Create + delete an AWS-provider ExternalDNS, confirm \`/tmp/<ns>-<name>-credential\` is gone