### PR TITLE
controller: requeue periodically to detect DNS drift

### DIFF
--- a/pkg/cmds/run.go
+++ b/pkg/cmds/run.go
@@ -18,6 +18,7 @@ package cmds
 
 import (
 	"os"
+	"time"
 
 	api "kubeops.dev/external-dns-operator/apis/external/v1alpha1"
 	controllers "kubeops.dev/external-dns-operator/pkg/controllers/external-dns"
@@ -55,6 +56,7 @@ func NewCmdRun() *cobra.Command {
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
+		reconcileInterval    time.Duration = 5 * time.Minute
 	)
 	cmd := &cobra.Command{
 		Use:               "run",
@@ -93,8 +95,9 @@ func NewCmdRun() *cobra.Command {
 			}
 
 			if err = (&controllers.ExternalDNSReconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:            mgr.GetClient(),
+				Scheme:            mgr.GetScheme(),
+				ReconcileInterval: reconcileInterval,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "ExternalDNS")
 				os.Exit(1)
@@ -127,6 +130,9 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	cmd.Flags().DurationVar(&reconcileInterval, "reconcile-interval", reconcileInterval,
+		"Requeue interval used to detect drift between desired and actual DNS state. "+
+			"Set to 0 to disable periodic requeue.")
 
 	return cmd
 }

--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -19,6 +19,7 @@ package externaldns
 import (
 	"context"
 	"sync"
+	"time"
 
 	api "kubeops.dev/external-dns-operator/apis/external/v1alpha1"
 	"kubeops.dev/external-dns-operator/pkg/credentials"
@@ -48,6 +49,12 @@ const finalizer = "externaldns.kubeops.dev/finalizer"
 type ExternalDNSReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// ReconcileInterval, if > 0, causes the reconciler to requeue every
+	// ExternalDNS after a successful reconcile. Without it, DNS drift
+	// against the upstream provider (manual edits, TTL expiry on cached
+	// answers) is invisible until a Source/Secret/CR event fires.
+	ReconcileInterval time.Duration
 
 	watcher *informers.ObjectTracker
 }
@@ -198,14 +205,14 @@ func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if len(dnsRecs) == 0 {
-		return ctrl.Result{}, r.updateEdnsStatus(
+		return ctrl.Result{RequeueAfter: r.ReconcileInterval}, r.updateEdnsStatus(
 			ctx,
 			edns,
 			newCondition(api.CreateAndApplyPlan, "no endpoints found for source", edns.Generation, true),
 			newPhase(api.ExternalDNSPhaseInProgress),
 		)
 	}
-	return ctrl.Result{}, r.updateEdnsStatus(
+	return ctrl.Result{RequeueAfter: r.ReconcileInterval}, r.updateEdnsStatus(
 		ctx,
 		edns,
 		newCondition(api.CreateAndApplyPlan, "plan applied", edns.Generation, true),


### PR DESCRIPTION
## Summary
The reconciler never returned \`RequeueAfter\` on success, so it only revisited an ExternalDNS when its Source / Secret / CR changed. Drift introduced outside the operator (manual provider edits, TTL turnover) stayed invisible until the next event.

- New field \`ExternalDNSReconciler.ReconcileInterval\` (default 5m, exposed via \`--reconcile-interval\`)
- Both success exits return \`{RequeueAfter: r.ReconcileInterval}\`
- \`--reconcile-interval=0\` preserves the old event-only behavior

## Test plan
- [ ] \`go build ./...\`
- [ ] Create an ExternalDNS, wait the interval, confirm a reconcile fires without touching the CR