### PR TITLE
controller, informers: validate source kind up front

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -127,6 +127,21 @@ func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	// Fail fast on an unsupported source kind so the user gets a clear
+	// message in Status, instead of an opaque "unknown kind" later in
+	// the informer setup or a silent passthrough to upstream.
+	if err := informers.ValidateSourceKind(edns.Spec.Source.Type.Kind); err != nil {
+		if patchErr := r.updateEdnsStatus(
+			ctx,
+			edns,
+			newCondition(api.CreateAndRegisterWatcher, err.Error(), edns.Generation, false),
+			newPhase(api.ExternalDNSPhaseFailed),
+		); patchErr != nil {
+			err = errors.Wrap(err, patchErr.Error())
+		}
+		return ctrl.Result{}, err
+	}
+
 	// REGISTER WATCHER
 	if err := informers.RegisterWatcher(ctx, edns, r.watcher, r.Client); err != nil {
 		if patchErr := r.updateEdnsStatus(

--- a/pkg/informers/sources.go
+++ b/pkg/informers/sources.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	api "kubeops.dev/external-dns-operator/apis/external/v1alpha1"
 
@@ -41,6 +42,21 @@ const (
 	kindService = "Service"
 	kindIngress = "Ingress"
 )
+
+// SupportedSourceKinds lists every source.Type.Kind value the operator
+// can wire an informer for. Anything else cannot be reconciled.
+var SupportedSourceKinds = []string{kindNode, kindService, kindIngress}
+
+// ValidateSourceKind returns a clear error when the given kind isn't a
+// source the operator implements. Use this at the top of Reconcile so
+// we fail fast with a useful message instead of getting an
+// "unknown kind" error from the informer registration step later.
+func ValidateSourceKind(kind string) error {
+	if slices.Contains(SupportedSourceKinds, kind) {
+		return nil
+	}
+	return fmt.Errorf("unsupported source kind %q (supported: %v)", kind, SupportedSourceKinds)
+}
 
 func getKindNode(cache cache.Cache, r client.Client) (source.SyncingSource, error) {
 	hdlr := handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, a *corev1.Node) []reconcile.Request {


### PR DESCRIPTION
## Summary
A typo in \`spec.source.type.kind\` would only surface as a vague \"unknown kind\" from informer registration — or worse, get lower-cased and passed opaquely to upstream and fail mysteriously.

- New \`informers.ValidateSourceKind\` listing the supported set (\`Node\`, \`Service\`, \`Ingress\`).
- Reconcile calls it at the top so the user sees a clear \"unsupported source kind X (supported: [...])\" message in Status and the Failed phase is set immediately.

## Test plan
- [ ] \`go build ./...\`
- [ ] Create an ExternalDNS with kind: \"Pod\" and confirm Status shows the new error + Failed phase