### PR TITLE
cmd: print the error before exiting non-zero

### DIFF
--- a/cmd/external-dns-operator/main.go
+++ b/cmd/external-dns-operator/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"kubeops.dev/external-dns-operator/pkg/cmds"
@@ -33,6 +34,7 @@ func main() {
 	defer logs.FlushLogs()
 
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
\`main\` swallowed the error from \`cmds.Execute()\` and exited 1 with no hint. Whatever cobra had silenced (validation issues, mis-typed flags) was lost. Print it to stderr first so operators can debug startup failures.

## Test plan
- [ ] \`go build ./...\`
- [ ] Run with a bad flag and confirm the error is printed before exit