### PR TITLE
cmds: scope scheme and setupLog inside NewCmdRun

### DIFF
--- a/pkg/cmds/run.go
+++ b/pkg/cmds/run.go
@@ -37,17 +37,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
-var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
-)
-
-func init() {
+func NewCmdRun() *cobra.Command {
+	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(api.AddToScheme(scheme))
-}
 
-func NewCmdRun() *cobra.Command {
+	setupLog := ctrl.Log.WithName("setup")
+
 	var (
 		// Reads go through the controller-runtime cache, not the API
 		// server, so the practical limit on outbound QPS is whatever the


### PR DESCRIPTION
## Summary
\`scheme\` and \`setupLog\` were package-level vars but were only used inside \`NewCmdRun\`. Move them inside the function; \`AddToScheme\` calls move from \`init()\` into the constructor so the package no longer has init-time side effects.

## Test plan
- [ ] \`go build ./...\`
- [ ] Start the operator and confirm both API types are registered as before