### PR TITLE
controller: lock before reading finalizer state in handleDeletion

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -214,12 +214,15 @@ func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func (r *ExternalDNSReconciler) handleDeletion(ctx context.Context, edns *api.ExternalDNS) (ctrl.Result, error) {
+	// Acquire the lock before reading finalizer state so we never observe
+	// "finalizer present" and then race with another goroutine that has
+	// already removed it and started a second cleanup pass.
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	if !controllerutil.ContainsFinalizer(edns, finalizer) {
 		return ctrl.Result{}, nil
 	}
-
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	if edns.Spec.Policy == nil || *edns.Spec.Policy == api.PolicySync {
 		if err := credentials.SetCredential(ctx, r.Client, edns); err != nil {


### PR DESCRIPTION
## Summary
\`handleDeletion\` used to check \`ContainsFinalizer\` first and only then acquire the serialization mutex. If \`MaxConcurrentReconciles\` is ever bumped above 1, two goroutines could both see \"finalizer present\" and race on the cleanup.

Acquire the lock up front so the finalizer check and the cleanup-then-remove sequence run as one critical section. Cheap correctness step that lets later PRs bump concurrency without revisiting this path.

## Test plan
- [ ] \`go build ./...\`
- [ ] Delete an ExternalDNS and confirm cleanup still happens exactly once and the finalizer is removed