### PR TITLE
api: activate kubebuilder Enum markers on Policy and Provider

### DIFF
--- a/apis/external/v1alpha1/constants.go
+++ b/apis/external/v1alpha1/constants.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// kubebuilder:validation:Enum:=sync;upsert-only;create-only
+// +kubebuilder:validation:Enum=sync;upsert-only;create-only
 type Policy string
 
 const (
@@ -39,7 +39,7 @@ const (
 	ExternalDNSPhaseInProgress ExternalDNSPhase = "InProgress"
 )
 
-// kubebuilder:validation:Enum:=aws;cloudflare;azure;google
+// +kubebuilder:validation:Enum=aws;cloudflare;azure;google
 type Provider string
 
 const (


### PR DESCRIPTION
## Summary
Both \`kubebuilder:validation:Enum\` lines on \`Policy\` and \`Provider\` were missing the leading \`+\`, so \`controller-gen\` treated them as plain comments. The generated CRD has \`type: string\` with no enum constraint on either field — which is why an arbitrary \`spec.provider\` string makes it past the API server today.

Add the \`+\` and drop the spurious \`:=\` (correct syntax is \`Enum=v1;v2;...\`).

> Note: \`make manifests\` (which runs in Docker) needs to be re-run to regenerate \`crds/external-dns.appscode.com_externaldnses.yaml\` with the enum constraint. Intentionally not bundled with this Go-source-only PR.

## Test plan
- [ ] \`go build ./...\`
- [ ] Run \`make manifests\` in CI / locally with Docker and inspect the regenerated CRD enum on \`policy\` and \`provider\`