### PR TITLE
plan, controller: drop noisy INFO endpoint dumps; use ErrorS

### DIFF
--- a/pkg/controllers/external-dns/externaldns_controller.go
+++ b/pkg/controllers/external-dns/externaldns_controller.go
@@ -280,7 +280,7 @@ func (r *ExternalDNSReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&core.Secret{}, secretToEdns).
 		Build(r)
 	if err != nil {
-		klog.Error("failed to build controller.", err.Error())
+		klog.ErrorS(err, "failed to build controller")
 		return err
 	}
 

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -263,7 +263,7 @@ func SetDNSRecords(ctx context.Context, edns *api.ExternalDNS) ([]api.DNSRecord,
 
 	endpointsSource, err := createEndpointsSource(ctx, cfg)
 	if err != nil {
-		klog.Error(err.Error())
+		klog.ErrorS(err, "failed to create endpoints source")
 		return nil, err
 	}
 
@@ -271,19 +271,19 @@ func SetDNSRecords(ctx context.Context, edns *api.ExternalDNS) ([]api.DNSRecord,
 
 	pvdr, err := buildProvider(ctx, cfg, domainFilter)
 	if err != nil {
-		klog.Error(err.Error())
+		klog.ErrorS(err, "failed to build provider")
 		return nil, err
 	}
 
 	reg, err := createRegistry(cfg, pvdr)
 	if err != nil {
-		klog.Errorln(err)
+		klog.ErrorS(err, "failed to create registry")
 		return nil, err
 	}
 
 	dnsRecs, err := createAndApplyPlan(ctx, cfg, reg, endpointsSource, domainFilter)
 	if err != nil {
-		klog.Errorln(err)
+		klog.ErrorS(err, "failed to apply plan")
 		return nil, err
 	}
 
@@ -389,8 +389,8 @@ func createAndApplyPlan(ctx context.Context, cfg *externaldns.Config, r registry
 	}
 
 	pln = pln.Calculate()
-	klog.Info("Desired: ", pln.Desired)
-	klog.Info("Current: ", pln.Current)
+	klog.V(2).InfoS("plan computed", "desired", len(pln.Desired), "current", len(pln.Current))
+	klog.V(4).InfoS("plan endpoints", "desired", pln.Desired, "current", pln.Current)
 
 	dnsRecs := make([]api.DNSRecord, 0)
 
@@ -402,7 +402,7 @@ func createAndApplyPlan(ctx context.Context, cfg *externaldns.Config, r registry
 	if pln.Changes.HasChanges() {
 		err = r.ApplyChanges(ctx, pln.Changes)
 		if err != nil {
-			klog.Error(err.Error())
+			klog.ErrorS(err, "failed to apply changes")
 			return nil, err
 		}
 		klog.Info("plan applied")


### PR DESCRIPTION
## Summary
- \`createAndApplyPlan\` logged the full desired/current endpoint slices at INFO on every reconcile. At any non-trivial zone size that's huge, unstructured, and contains target IPs nobody wants in steady-state operator logs. Replaced with a structured one-line summary at \`V(2)\` (counts only) and the full dump at \`V(4)\` for debugging.
- Replace \`klog.Error(err.Error())\` / \`klog.Errorln(err)\` with \`klog.ErrorS\` so the structured logger gets a real \`err\` field and a short message per failure site.
- In the controller, \`klog.Error(\"failed to build controller.\", err.Error())\` passed two args to a variadic-interface function and dropped the structured field. Switched to \`klog.ErrorS\`.

## Test plan
- [ ] \`go build ./...\`
- [ ] Run with \`-v=0\` and confirm endpoint dumps are gone; \`-v=4\` brings them back