### PR TITLE
cmds: document why QPS/Burst defaults are intentionally huge

### DIFF
--- a/pkg/cmds/run.go
+++ b/pkg/cmds/run.go
@@ -49,6 +49,13 @@ func init() {
 
 func NewCmdRun() *cobra.Command {
 	var (
+		// Reads go through the controller-runtime cache, not the API
+		// server, so the practical limit on outbound QPS is whatever the
+		// reconciler does on writes (status patches, finalizer updates).
+		// Setting QPS/Burst this high effectively disables the
+		// client-side rate limiter — what we want, because the only
+		// effect of throttling here is to add latency to those writes on
+		// cold start / leader handoff.
 		QPS   float32 = 1e6
 		Burst int     = 1e6
 


### PR DESCRIPTION
## Summary
\`QPS=1e6 / Burst=1e6\` looks like an accident on first read. It isn't — reads go through the cache, so the rate limit only ever applies to writes (status patches, finalizer updates), and throttling those just adds cold-start / leader-handoff latency. Add a comment so the next reader doesn't \"fix\" them.

## Test plan
- [ ] \`go build ./...\`